### PR TITLE
Resolve Docker Building Hang-up

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Node.js image as a base image
-FROM node:lts
+FROM node:21.7.3
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
# Pull Request Template

## Screenshots
N/A

## Description
This is a (hopefully temporary) fix for the issue encountered when running `docker compose build` where execution would hang at `RUN npm install`. Specifying and downgrading the node version to 21.7.3 in the Dockerfile resolves this.  

Fixes # No Issue

## Additional Information
N/A

## Checklist:
Before you submit your Pull Request, please make sure you have completed the following tasks:
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have tagged my PR with the appropriate label(s).
